### PR TITLE
Move createGuiItem methods to their own util class

### DIFF
--- a/src/main/java/net/seanomik/energeticstorage/gui/ESDriveGUI.java
+++ b/src/main/java/net/seanomik/energeticstorage/gui/ESDriveGUI.java
@@ -1,7 +1,6 @@
 package net.seanomik.energeticstorage.gui;
 
 import de.tr7zw.changeme.nbtapi.NBTItem;
-import net.seanomik.energeticstorage.EnergeticStorage;
 import net.seanomik.energeticstorage.files.PlayersFile;
 import net.seanomik.energeticstorage.objects.ESDrive;
 import net.seanomik.energeticstorage.objects.ESSystem;
@@ -17,9 +16,14 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import static net.seanomik.energeticstorage.utils.GUIHelper.createGuiItem;
 
 public class ESDriveGUI implements InventoryHolder, Listener {
     private final Inventory globalInv;
@@ -63,34 +67,6 @@ public class ESDriveGUI implements InventoryHolder, Listener {
                 inv.setItem(i, drive.getDriveItem());
             }
         }
-    }
-
-    private ItemStack createGuiItem(Material material, String name, List<String> description) {
-        ItemStack item = new ItemStack(material, 1);
-        ItemMeta meta = item.getItemMeta();
-        meta.setDisplayName(name);
-        meta.setLore(description);
-        item.setItemMeta(meta);
-
-        return item;
-    }
-
-    private ItemStack createGuiItem(Material material, List<String> description) {
-        ItemStack item = new ItemStack(material, 1);
-        ItemMeta meta = item.getItemMeta();
-        meta.setLore(description);
-        item.setItemMeta(meta);
-
-        return item;
-    }
-
-    private ItemStack createGuiItem(Material material, String name) {
-        ItemStack item = new ItemStack(material, 1);
-        ItemMeta meta = item.getItemMeta();
-        meta.setDisplayName(name);
-        item.setItemMeta(meta);
-
-        return item;
     }
 
     // You can open the inventory with this

--- a/src/main/java/net/seanomik/energeticstorage/gui/ESSystemSecurityGUI.java
+++ b/src/main/java/net/seanomik/energeticstorage/gui/ESSystemSecurityGUI.java
@@ -18,10 +18,15 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static net.seanomik.energeticstorage.utils.GUIHelper.createGuiItem;
 
 public class ESSystemSecurityGUI implements InventoryHolder, Listener {
     private final Inventory inv;
@@ -113,34 +118,6 @@ public class ESSystemSecurityGUI implements InventoryHolder, Listener {
             inv.setItem(48, createGuiItem(Material.PAPER, "Last page"));
             inv.setItem(50, createGuiItem(Material.PAPER, "Next page"));
         }
-    }
-
-    private ItemStack createGuiItem(Material material, String name, List<String> description) {
-        ItemStack item = new ItemStack(material, 1);
-        ItemMeta meta = item.getItemMeta();
-        meta.setDisplayName(name);
-        meta.setLore(description);
-        item.setItemMeta(meta);
-
-        return item;
-    }
-
-    private ItemStack createGuiItem(Material material, List<String> description) {
-        ItemStack item = new ItemStack(material, 1);
-        ItemMeta meta = item.getItemMeta();
-        meta.setLore(description);
-        item.setItemMeta(meta);
-
-        return item;
-    }
-
-    private ItemStack createGuiItem(Material material, String name) {
-        ItemStack item = new ItemStack(material, 1);
-        ItemMeta meta = item.getItemMeta();
-        meta.setDisplayName(name);
-        item.setItemMeta(meta);
-
-        return item;
     }
 
     public void openInventory(Player p, ESSystem esSystem) {

--- a/src/main/java/net/seanomik/energeticstorage/gui/ESTerminalGUI.java
+++ b/src/main/java/net/seanomik/energeticstorage/gui/ESTerminalGUI.java
@@ -10,8 +10,6 @@ import net.wesjd.anvilgui.AnvilGUI;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -24,7 +22,15 @@ import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static net.seanomik.energeticstorage.utils.GUIHelper.createGuiItem;
 
 public class ESTerminalGUI implements InventoryHolder, Listener {
     private final Inventory globalInv;
@@ -206,25 +212,6 @@ public class ESTerminalGUI implements InventoryHolder, Listener {
 
             inv.setItem(47, createGuiItem(Material.HOPPER, "Sort by " + openSystem.getSortOrder().toDisplayString()));
         }
-    }
-
-    private ItemStack createGuiItem(Material material, String name) {
-        ItemStack item = new ItemStack(material, 1);
-        ItemMeta meta = item.getItemMeta();
-        meta.setDisplayName(name);
-        item.setItemMeta(meta);
-
-        return item;
-    }
-
-    private ItemStack createGuiItem(Material material, String name, List<String> lore) {
-        ItemStack item = new ItemStack(material, 1);
-        ItemMeta meta = item.getItemMeta();
-        meta.setDisplayName(name);
-        meta.setLore(lore);
-        item.setItemMeta(meta);
-
-        return item;
     }
 
     private enum ClickType {

--- a/src/main/java/net/seanomik/energeticstorage/utils/GUIHelper.java
+++ b/src/main/java/net/seanomik/energeticstorage/utils/GUIHelper.java
@@ -1,0 +1,57 @@
+package net.seanomik.energeticstorage.utils;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class GUIHelper {
+    /**
+     * Creates a GUI Item with a given material, display name, and optional lore
+     *
+     * @param material The material to use
+     * @param name     The name of the item
+     * @param lore     Optional lore to add to the item
+     * @return An item stack to be used in the GUI.
+     */
+    public static ItemStack createGuiItem(Material material, String name, String... lore) {
+        ItemStack item = new ItemStack(material, 1);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RESET + name);
+
+            if (lore.length > 0) {
+                ArrayList<String> metaLore = new ArrayList<>(Arrays.asList(lore));
+                meta.setLore(metaLore);
+            }
+
+            item.setItemMeta(meta);
+        }
+
+        return item;
+    }
+
+    /**
+     * Creates a GUI item with given material, display name, and required lore
+     *
+     * @param material The material to use
+     * @param name     The name of the item
+     * @param lore     Optional lore to add to the item
+     * @return An item stack to be used in the GUI.
+     */
+    public static ItemStack createGuiItem(Material material, String name, List<String> lore) {
+        ItemStack item = new ItemStack(material, 1);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RESET + name);
+            meta.setLore(lore);
+        }
+        item.setItemMeta(meta);
+
+        return item;
+    }
+}


### PR DESCRIPTION
I moved some duplicate code!

This PR also adds a reset character before every display name, meaning the days of italic item names are over!

![image](https://user-images.githubusercontent.com/8278263/134826800-5f2847be-3b78-49f6-b8b5-577787d5f886.png)

This PR also properly hides the name of items:
![image](https://user-images.githubusercontent.com/8278263/134826796-f935c105-7e7c-49c8-bc0a-9761215df841.png)

Because the functions are imported statically, you can use createGuiItem as usual!